### PR TITLE
setup app context to enable using a emulator DB during tests

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Bootcamp

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -16,6 +16,35 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1576417822">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="A209FRGJ0201" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Fairphone&#10; FP3" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-957912072">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="A209FRGJ0201" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Fairphone&#10; FP3" value="120" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-928399285">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_2_API_33.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-03-23T18:14:46.212985Z" />
+  </component>
+</project>

--- a/app/src/androidTest/java/com/github/campus_capture/bootcamp/MainActivityRuleFragmentTest.java
+++ b/app/src/androidTest/java/com/github/campus_capture/bootcamp/MainActivityRuleFragmentTest.java
@@ -1,10 +1,15 @@
 package com.github.campus_capture.bootcamp;
 
+import static android.content.ContentValues.TAG;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.containsString;
 
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;
@@ -12,7 +17,17 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.github.campus_capture.bootcamp.activities.MainActivity;
+import com.github.campus_capture.bootcamp.firebase.FireDatabase;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,20 +36,65 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class MainActivityRuleFragmentTest {
 
+    static FirebaseDatabase database = null;
+
     @Rule
     public ActivityScenarioRule<MainActivity> testRule = new ActivityScenarioRule<>(MainActivity.class);
 
-    @Ignore("We can only test it once we have a proper mock DB we can inject")
+    @BeforeClass
+    public static void init_firebase_emulator() {
+
+        try{
+            AppContext context = (AppContext)ApplicationProvider.getApplicationContext();
+            database = context.getFirebaseDB();
+            database.useEmulator("127.0.0.1", 9000);
+
+            //check for connection
+            DatabaseReference connectedRef = FirebaseDatabase.getInstance().getReference(".info/connected");
+            connectedRef.addValueEventListener(new ValueEventListener() {
+                @Override
+                public void onDataChange(@NonNull DataSnapshot snapshot) {
+                    boolean connected = snapshot.getValue(Boolean.class);
+                    if (connected) {
+                        Log.d(TAG, "connected");
+                    } else {
+                        Log.d(TAG, "not connected");
+                    }
+                }
+
+                @Override
+                public void onCancelled(@NonNull DatabaseError error) {
+                    Log.w(TAG, "Listener was cancelled");
+                }
+            });
+
+        } catch (Exception e) {
+            Log.e("Error init DB", e.toString());
+        }
+    }
+
+    @Before
+    public void clear_firebase_database(){
+        database.getReference().setValue(null);
+    }
+
+    @Ignore //TODO comment out once firebase emulator is setup on CI
     @Test
     public void RulesFragmentShowTheRightContent() {
+        AppContext context = (AppContext)ApplicationProvider.getApplicationContext();
+
+        database.getReference().child("rules").setValue("The rules stocked in firebase emulator...");
+
         Intents.init();
 
         onView(ViewMatchers.withContentDescription("Navigate up"))
                 .perform(ViewActions.click());
 
-        onView(ViewMatchers.withId(R.id.nav_rules)).perform(ViewActions.click());
+        onView(ViewMatchers.withId(R.id.nav_rules))
+                .perform(ViewActions.click());
 
-        onView(ViewMatchers.withId(R.id.rules_text)).check(matches(withText(containsString("The rules stocked in firebase..."))));
+        onView(ViewMatchers.withId(R.id.rules_text))
+                .check(matches(withText(containsString("The rules stocked in firebase emulator..."))));
 
         Intents.release();
     }

--- a/app/src/androidTest/java/com/github/campus_capture/bootcamp/MainActivityRuleFragmentTest.java
+++ b/app/src/androidTest/java/com/github/campus_capture/bootcamp/MainActivityRuleFragmentTest.java
@@ -81,8 +81,6 @@ public class MainActivityRuleFragmentTest {
     @Ignore //TODO comment out once firebase emulator is setup on CI
     @Test
     public void RulesFragmentShowTheRightContent() {
-        AppContext context = (AppContext)ApplicationProvider.getApplicationContext();
-
         database.getReference().child("rules").setValue("The rules stocked in firebase emulator...");
 
         Intents.init();

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application
+        android:name=".AppContext"
+
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/github/campus_capture/bootcamp/AppContext.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/AppContext.java
@@ -1,0 +1,19 @@
+package com.github.campus_capture.bootcamp;
+
+import android.app.Application;
+
+import com.google.firebase.database.FirebaseDatabase;
+
+public class AppContext extends Application {
+    private FirebaseDatabase db = null;
+
+    public FirebaseDatabase getFirebaseDB(){
+        if(db == null) {
+            db = FirebaseDatabase.getInstance();
+
+            // enable caching
+            db.setPersistenceEnabled(true);
+        }
+        return db;
+    }
+}

--- a/app/src/main/java/com/github/campus_capture/bootcamp/fragments/RulesFragment.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/fragments/RulesFragment.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.github.campus_capture.bootcamp.AppContext;
 import com.github.campus_capture.bootcamp.R;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -69,8 +70,9 @@ public class RulesFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         this.rulesText = (TextView) getView().findViewById(R.id.rules_text);
 
-        DatabaseReference myRef = database.getReference("rules");
+        AppContext context = (AppContext) getContext().getApplicationContext();
 
+        DatabaseReference myRef = context.getFirebaseDB().getReference("rules");
 
         // Read from the database
         myRef.addValueEventListener(new ValueEventListener() {

--- a/app/src/test/java/com/github/campus_capture/bootcamp/ExampleUnitTest.java
+++ b/app/src/test/java/com/github/campus_capture/bootcamp/ExampleUnitTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import com.google.firebase.database.FirebaseDatabase;
+
 /**
  * Example local unit test, which will execute on the development machine (host).
  *
@@ -14,4 +16,5 @@ public class ExampleUnitTest {
     public void addition_isCorrect() {
         assertEquals(4, 2 + 2);
     }
+
 }


### PR DESCRIPTION
#49 This should enable using an emulator DB for unit tests tho I didn't manage to connect to the emulator.

edit : updated the wiki https://github.com/Campus-Capture/campus-capture/wiki/App-architecture#accessing-the-firebasedatabase-instance