### PR TITLE
Dev google maps testing

### DIFF
--- a/app/src/androidTest/java/com/github/campus_capture/bootcamp/fragments/MapColorTest.java
+++ b/app/src/androidTest/java/com/github/campus_capture/bootcamp/fragments/MapColorTest.java
@@ -18,7 +18,9 @@ import static com.github.campus_capture.bootcamp.authentication.Section.SV;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.matcher.ViewMatchers;
@@ -30,11 +32,14 @@ import com.github.campus_capture.bootcamp.R;
 import com.github.campus_capture.bootcamp.activities.MainActivity;
 import com.github.campus_capture.bootcamp.authentication.Section;
 import com.github.campus_capture.bootcamp.firebase.BackendInterface;
+import com.github.campus_capture.bootcamp.firebase.FirebaseBackend;
 import com.github.campus_capture.bootcamp.firebase.PlaceholderBackend;
+import com.github.campus_capture.bootcamp.map.MapScheduler;
 import com.github.campus_capture.bootcamp.scoreboard.ScoreItem;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,38 +51,17 @@ import java.util.concurrent.CompletableFuture;
 
 public class MapColorTest {
 
-    private final BackendInterface mockColor = new PlaceholderBackend() {
-        @Override
-        public CompletableFuture<Boolean> hasAttacked(String uid) {
-            return CompletableFuture.completedFuture(false);
-        }
-
-        @Override
-        public CompletableFuture<Map<String, Section>> getCurrentZoneOwners() {
-            Map<String, Section> out = new HashMap<>();
-            out.put("SG1", AR);
-            out.put("CO Est", GC);
-            out.put("CO Ouest", SIE);
-            out.put("BC", IN);
-            out.put("INM INR Terasse", SC);
-            out.put("INM", CGC);
-            out.put("INF INJ", MA);
-            out.put("MXC MXD", PH);
-            out.put("MXG Terrasse", EL);
-            out.put("MXE MXH", SV);
-            out.put("ELA ELB", MX);
-            out.put("ELL", GM);
-            out.put("SV AI", MT);
-            out.put("Agora", NONE);
-            return CompletableFuture.completedFuture(out);
-        }
-    };
-
     @Rule
     public ActivityScenarioRule<MainActivity> testRule = new ActivityScenarioRule<>(MainActivity.class);
 
     @Rule
     public GrantPermissionRule permissionLocation = GrantPermissionRule.grant("android.permission.ACCESS_FINE_LOCATION");
+
+    @BeforeClass
+    public static void initClass()
+    {
+        MainActivity.backendInterface = new PlaceholderBackend();
+    }
 
     @Before
     public void init()
@@ -89,27 +73,14 @@ public class MapColorTest {
     @After
     public void close()
     {
-        Intents.release();
+        //Intents.release();
     }
 
-    @Ignore("Testing this is literally horrible; future me will figure it out")
+    //@Ignore("Testing this is literally horrible; future me will figure it out")
     @Test
     public void testZoneColors() throws InterruptedException {
-        // TODO write some actual tests
-        // Meanwhile: don't touch my spaghet
 
-        MainActivity.backendInterface = mockColor;
-
-        Intents.init();
-
-        Thread.sleep(5000);
-
-        onView(ViewMatchers.withContentDescription("Navigate up"))
-                .perform(ViewActions.click());
-
-        onView(ViewMatchers.withId(R.id.nav_maps)).perform(ViewActions.click());
-
-        Thread.sleep(5000);
+        Thread.sleep(30000);
     }
 
 }

--- a/app/src/androidTest/java/com/github/campus_capture/bootcamp/fragments/MapColorTest.java
+++ b/app/src/androidTest/java/com/github/campus_capture/bootcamp/fragments/MapColorTest.java
@@ -16,9 +16,21 @@ import static com.github.campus_capture.bootcamp.authentication.Section.SC;
 import static com.github.campus_capture.bootcamp.authentication.Section.SIE;
 import static com.github.campus_capture.bootcamp.authentication.Section.SV;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import static java.lang.System.out;
+
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Environment;
+import android.util.Log;
+import android.view.View;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.action.ViewActions;
@@ -44,12 +56,16 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class MapColorTest {
+
+    private static final double DELTA_VAL = 1;
 
     @Rule
     public ActivityScenarioRule<MainActivity> testRule = new ActivityScenarioRule<>(MainActivity.class);
@@ -76,11 +92,65 @@ public class MapColorTest {
         //Intents.release();
     }
 
-    //@Ignore("Testing this is literally horrible; future me will figure it out")
     @Test
     public void testZoneColors() throws InterruptedException {
 
-        Thread.sleep(30000);
+        // Note: this test currently doesn't work, just because I am out of energy to tackle this.
+        // The gist is to take the maps view-port, export it to a bitmap, and then read the
+        // individual pixels of the generated image to check that the colors of the displayed
+        // zones are correct. Unfortunately, it doesn't work, and for now I didn't find any way
+        // of retrieving the image somehow to make out what is actually going on when the test
+        // is run. Oops!
+
+        Thread.sleep(6000);
+        /*
+        testRule.getScenario().onActivity(a -> {
+            View v = a.findViewById(R.id.map);
+            Bitmap b = getBitmapFromView(v);
+
+            // Testing every color is stupid, as such we'll be checking the three in the viewport
+
+            // MX:
+            int pixel = b.getPixel(150,975);
+            Color color = Color.valueOf(pixel);
+            assertEquals(color.red(), 253, DELTA_VAL);
+            assertEquals(color.green(), 216, DELTA_VAL);
+            assertEquals(color.blue(), 187, DELTA_VAL);
+
+            // SIE:
+            pixel = b.getPixel(438,1005);
+            color = Color.valueOf(pixel);
+            assertEquals(color.red(), 206, DELTA_VAL);
+            assertEquals(color.green(), 253, DELTA_VAL);
+            assertEquals(color.blue(), 247, DELTA_VAL);
+
+            // MX:
+            pixel = b.getPixel(881,936);
+            color = Color.valueOf(pixel);
+            assertEquals(color.red(), 206, DELTA_VAL);
+            assertEquals(color.green(), 138, DELTA_VAL);
+            assertEquals(color.blue(), 188, DELTA_VAL);
+        });*/
+    }
+
+    // Helper method, taken from https://stackoverflow.com/questions/5536066/convert-view-to-bitmap-on-android
+    private Bitmap getBitmapFromView(View view) {
+        //Define a bitmap with the same size as the view
+        Bitmap returnedBitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(),Bitmap.Config.ARGB_8888);
+        //Bind a canvas to it
+        Canvas canvas = new Canvas(returnedBitmap);
+        //Get the view's background
+        Drawable bgDrawable =view.getBackground();
+        if (bgDrawable!=null)
+            //has background drawable, then draw it on the canvas
+            bgDrawable.draw(canvas);
+        else
+            //does not have background drawable, then draw white background on the canvas
+            canvas.drawColor(Color.WHITE);
+        // draw the view on the canvas
+        view.draw(canvas);
+        //return the bitmap
+        return returnedBitmap;
     }
 
 }

--- a/app/src/androidTest/java/com/github/campus_capture/bootcamp/fragments/MapColorTest.java
+++ b/app/src/androidTest/java/com/github/campus_capture/bootcamp/fragments/MapColorTest.java
@@ -1,20 +1,8 @@
 package com.github.campus_capture.bootcamp.fragments;
 
 import static androidx.test.espresso.Espresso.onView;
-import static com.github.campus_capture.bootcamp.authentication.Section.AR;
-import static com.github.campus_capture.bootcamp.authentication.Section.CGC;
-import static com.github.campus_capture.bootcamp.authentication.Section.EL;
-import static com.github.campus_capture.bootcamp.authentication.Section.GC;
-import static com.github.campus_capture.bootcamp.authentication.Section.GM;
-import static com.github.campus_capture.bootcamp.authentication.Section.IN;
-import static com.github.campus_capture.bootcamp.authentication.Section.MA;
-import static com.github.campus_capture.bootcamp.authentication.Section.MT;
-import static com.github.campus_capture.bootcamp.authentication.Section.MX;
-import static com.github.campus_capture.bootcamp.authentication.Section.NONE;
-import static com.github.campus_capture.bootcamp.authentication.Section.PH;
-import static com.github.campus_capture.bootcamp.authentication.Section.SC;
-import static com.github.campus_capture.bootcamp.authentication.Section.SIE;
-import static com.github.campus_capture.bootcamp.authentication.Section.SV;
+import static com.github.campus_capture.bootcamp.authentication.Section.*;
+
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -92,6 +80,8 @@ public class MapColorTest {
         //Intents.release();
     }
 
+    //TODO: Revolve in issue #153
+    @Ignore("To be (maybe) tested in issue #153")
     @Test
     public void testZoneColors() throws InterruptedException {
 
@@ -102,7 +92,7 @@ public class MapColorTest {
         // of retrieving the image somehow to make out what is actually going on when the test
         // is run. Oops!
 
-        Thread.sleep(6000);
+        //Thread.sleep(6000);
         /*
         testRule.getScenario().onActivity(a -> {
             View v = a.findViewById(R.id.map);

--- a/app/src/main/java/com/github/campus_capture/bootcamp/firebase/PlaceholderBackend.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/firebase/PlaceholderBackend.java
@@ -54,6 +54,9 @@ public class PlaceholderBackend implements BackendInterface {
         out.put("ELL", GM);
         out.put("SV AI", MT);
         out.put("Agora", NONE);
+        out.put("CE", PH);
+        out.put("Sat Terrasse", SIE);
+        out.put("CM ME", MX);
         return CompletableFuture.completedFuture(out);
     }
 

--- a/app/src/main/java/com/github/campus_capture/bootcamp/firebase/PlaceholderBackend.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/firebase/PlaceholderBackend.java
@@ -1,5 +1,20 @@
 package com.github.campus_capture.bootcamp.firebase;
 
+import static com.github.campus_capture.bootcamp.authentication.Section.AR;
+import static com.github.campus_capture.bootcamp.authentication.Section.CGC;
+import static com.github.campus_capture.bootcamp.authentication.Section.EL;
+import static com.github.campus_capture.bootcamp.authentication.Section.GC;
+import static com.github.campus_capture.bootcamp.authentication.Section.GM;
+import static com.github.campus_capture.bootcamp.authentication.Section.IN;
+import static com.github.campus_capture.bootcamp.authentication.Section.MA;
+import static com.github.campus_capture.bootcamp.authentication.Section.MT;
+import static com.github.campus_capture.bootcamp.authentication.Section.MX;
+import static com.github.campus_capture.bootcamp.authentication.Section.NONE;
+import static com.github.campus_capture.bootcamp.authentication.Section.PH;
+import static com.github.campus_capture.bootcamp.authentication.Section.SC;
+import static com.github.campus_capture.bootcamp.authentication.Section.SIE;
+import static com.github.campus_capture.bootcamp.authentication.Section.SV;
+
 import com.github.campus_capture.bootcamp.authentication.Section;
 import com.github.campus_capture.bootcamp.scoreboard.ScoreItem;
 import com.github.campus_capture.bootcamp.shop.PowerUp;
@@ -25,7 +40,20 @@ public class PlaceholderBackend implements BackendInterface {
     @Override
     public CompletableFuture<Map<String, Section>> getCurrentZoneOwners() {
         Map<String, Section> out = new HashMap<>();
-        out.put("campus", Section.IN);
+        out.put("SG1", AR);
+        out.put("CO Est", GC);
+        out.put("CO Ouest", SIE);
+        out.put("BC", IN);
+        out.put("INM INR Terasse", SC);
+        out.put("INM", CGC);
+        out.put("INF INJ", MA);
+        out.put("MXC MXD", PH);
+        out.put("MXG Terrasse", EL);
+        out.put("MXE MXH", SV);
+        out.put("ELA ELB", MX);
+        out.put("ELL", GM);
+        out.put("SV AI", MT);
+        out.put("Agora", NONE);
         return CompletableFuture.completedFuture(out);
     }
 

--- a/app/src/main/java/com/github/campus_capture/bootcamp/fragments/MapsFragment.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/fragments/MapsFragment.java
@@ -177,7 +177,7 @@ public class MapsFragment extends Fragment implements GoogleMap.OnCameraMoveList
             }
         });
 
-        // scheduler.startAll();
+        scheduler.startColorRefresh();
     };
 
     /**
@@ -397,13 +397,15 @@ public class MapsFragment extends Fragment implements GoogleMap.OnCameraMoveList
      */
     public void refreshZoneColors(Map<String, Section> zoneState)
     {
-        if(zoneState == null)
+        Log.i("MapsFragment", "Refreshing zone colours");
+        if(zoneState == null || polygonMap == null)
         {
             Log.e("MapsFragment", "Error: empty zone state returned");
             return;
         }
         for(String name : zoneState.keySet())
         {
+            Log.i("MapsFragment", "Zone " + name);
             Section s = zoneState.get(name);
             if(s == null)
             {

--- a/app/src/main/java/com/github/campus_capture/bootcamp/map/MapScheduler.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/map/MapScheduler.java
@@ -280,4 +280,14 @@ public class MapScheduler {
     {
         return isTakeover;
     }
+
+    /**
+     * Getter to retrieve the section owning the current zone
+     * @param name the name of the zone
+     * @return the section
+     */
+    public Section getCurrentZoneOwner(String name)
+    {
+        return zoneState.get(name);
+    }
 }

--- a/app/src/main/java/com/github/campus_capture/bootcamp/map/MapScheduler.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/map/MapScheduler.java
@@ -141,7 +141,6 @@ public class MapScheduler {
         attackButton = view.findViewById(R.id.attackButton);
         defendButton = view.findViewById(R.id.defendButton);
         timerButton = view.findViewById(R.id.timerButton);
-        refreshZoneState.run();
 
         if(!overrideTime)
         {
@@ -159,7 +158,7 @@ public class MapScheduler {
     }
 
     /**
-     * Method to start the processes
+     * Method to start the processes, except the zone color refresh (needs to wait for the map)
      */
     public void startAll() {
         long millisSinceHour = time.get(Calendar.MINUTE) * MILLIS_PER_MIN
@@ -199,6 +198,14 @@ public class MapScheduler {
         });
 
         zoneRefreshTask.run();
+    }
+
+    /**
+     * Method to start the color refreshes
+     */
+    public void startColorRefresh()
+    {
+        refreshZoneState.run();
     }
 
     /**

--- a/app/src/test/java/com/github/campus_capture/bootcamp/PlaceholderBackendInterfaceTest.java
+++ b/app/src/test/java/com/github/campus_capture/bootcamp/PlaceholderBackendInterfaceTest.java
@@ -40,6 +40,7 @@ public class PlaceholderBackendInterfaceTest {
         }
     }
 
+
     @Test
     public void testScoresAreWellOrdered()
     {

--- a/app/src/test/java/com/github/campus_capture/bootcamp/PlaceholderBackendInterfaceTest.java
+++ b/app/src/test/java/com/github/campus_capture/bootcamp/PlaceholderBackendInterfaceTest.java
@@ -34,7 +34,7 @@ public class PlaceholderBackendInterfaceTest {
 
         try{
             Map<String, Section> owners = t.getCurrentZoneOwners().get();
-            assertEquals(owners.get("campus"), Section.IN);
+            assertEquals(owners.get("CE"), Section.PH);
         }catch(Exception e){
             fail();
         }


### PR DESCRIPTION
So, this PR achieved nothing than proving once more that Google Map's API is an old, janky, decrepit and untestable piece of garbage. Since the viewport for Google Maps is image-based, there's no chance of retrieving any info from Espresso, and as such would require some kind of workaround. The one I tried is capturing the viewport image and reading pixel data from it, but that didn't work either. 

If this already fails just to read the colours from the zones on the map according to the owners, then there's no way in hell it will be able to read the markers' descriptions on who's currently attacking a zone. Flat out.

Still, this PR fixes an injection bug which was in the colour tests previously, so at least we know that every section's colour is displayed at least once, and also retimed the update of the zone colors to be more coherent with the map's behavior.