### PR TITLE
UID added at first login

### DIFF
--- a/app/src/main/java/com/github/campus_capture/bootcamp/fragments/SignInFragment.java
+++ b/app/src/main/java/com/github/campus_capture/bootcamp/fragments/SignInFragment.java
@@ -181,6 +181,8 @@ public class SignInFragment extends Fragment {
     private CompletableFuture<Void> storeUserInfo(String uid) {
         CompletableFuture<Section> futureSection = new CompletableFuture<>();
         if(firstLogin) {
+            // Set uid
+            User.setUid(uid);
             // Fetch section info from User class
             Section section = User.getSection();
             storeUserOnDB(uid, section);


### PR DESCRIPTION
I think this is the smallest of the requests. The userID is just set at the first login. With that, the MainActivity can detect that the user is not a spectator and acts in consequence.